### PR TITLE
Support gift since_start parsing

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -110,28 +110,31 @@ def handle_response_code(code: int) -> str:
     }
     return code_messages.get(code, f"未知错误，错误码：{code}")
 
-def filter_danmaku(danmaku_list: List[Tuple[float, str]], max_count_per_hour: int = 500, max_repeat_count: int = 1) -> List[Tuple[float, str]]:
-    """
-    过滤弹幕，确保均匀分布、去重，并且过滤包含禁用关键词的弹幕
+def filter_danmaku(
+    danmaku_list: List[Tuple[float, str, str, str]],
+    max_count_per_hour: int = 500,
+    max_repeat_count: int = 1,
+) -> List[Tuple[float, str]]:
+    """根据原始内容过滤弹幕并均匀分布普通弹幕
 
-    参数:
-        danmaku_list: 原始弹幕列表 [(时间戳, 内容),...]
-        max_count_per_hour: 每小时最大弹幕数
-        max_repeat_count: 允许的最大重复次数
-    返回:
-        过滤后的弹幕列表
+    ``danmaku_list`` 每项为 ``(timestamp, message, original, type)``，其中
+    ``type`` 为 ``"d"`` 或 ``"gift"``。礼物弹幕不会被计入频率限制或重复
+    限制，但仍会按时间排序返回。
     """
     if not danmaku_list:
         return []
     
     # 从配置中获取禁用关键词列表
     banned_keywords = config.danmaku.get("ban_keywords", [])
-    
-    # 先过滤掉包含禁用关键词的弹幕
+
+    # 先过滤掉包含禁用关键词的弹幕（礼物弹幕不过滤）
     danmaku_list = [
-        (timestamp, content) 
-        for timestamp, content in danmaku_list 
-        if content and not any(keyword in content for keyword in banned_keywords)
+        item
+        for item in danmaku_list
+        if (
+            item[3] == "gift"
+            or (item[2] and not any(k in item[2] for k in banned_keywords))
+        )
     ]
 
     # 如果全部弹幕均被过滤，则直接返回空列表
@@ -141,19 +144,25 @@ def filter_danmaku(danmaku_list: List[Tuple[float, str]], max_count_per_hour: in
     # 按时间排序
     danmaku_list.sort(key=lambda x: x[0])
     
-    # 去重并检查重复次数
-    seen_contents = {}
-    unique_danmaku = []
-    for timestamp, content in danmaku_list:
-        # 检查当前内容的出现次数
-        seen_contents[content] = seen_contents.get(content, 0) + 1
-        
-        # 如果内容出现的次数小于等于允许的最大重复次数，则保留
-        if seen_contents[content] <= max_repeat_count:
-            unique_danmaku.append((timestamp, content))
+    # 去重并检查重复次数（礼物弹幕不去重）
+    seen_contents: dict[str, int] = {}
+    unique_danmaku: List[Tuple[float, str, str, str]] = []
+    for item in danmaku_list:
+        ts, msg, orig, typ = item
+        if typ == "gift":
+            unique_danmaku.append(item)
+            continue
+        seen_contents[orig] = seen_contents.get(orig, 0) + 1
+        if seen_contents[orig] <= max_repeat_count:
+            unique_danmaku.append(item)
+
+    # 筛选出普通弹幕用于计算频率
+    normal_danmaku = [d for d in unique_danmaku if d[3] != "gift"]
+    if not normal_danmaku:
+        return [(t, m) for t, m, _, _ in unique_danmaku]
 
     # 获取视频总时长（小时）
-    video_duration = danmaku_list[-1][0] / 3600
+    video_duration = (normal_danmaku[-1][0] - normal_danmaku[0][0]) / 3600
     
     # 计算实际每小时最大弹幕数
     max_count = int(max_count_per_hour * video_duration)
@@ -161,63 +170,133 @@ def filter_danmaku(danmaku_list: List[Tuple[float, str]], max_count_per_hour: in
         return []
     
     # 如果去重后数量小于限制，直接返回
-    if len(unique_danmaku) <= max_count:
-        return unique_danmaku
-    
-    # 计算时间窗口大小，确保弹幕均匀分布
-    window_size = (unique_danmaku[-1][0] - unique_danmaku[0][0]) / max_count
-    
-    # 使用滑动窗口选择弹幕
-    filtered_danmaku = []
-    current_window_start = unique_danmaku[0][0]
-    window_danmaku = []
-    
-    for i, (timestamp, content) in enumerate(unique_danmaku):
-        if len(filtered_danmaku) + (len(unique_danmaku) - i) <= max_count:
-            # 加上当前窗口的弹幕（如果有）
-            if window_danmaku:
-                mid_idx = len(window_danmaku) // 2
-                filtered_danmaku.append(window_danmaku[mid_idx])
+    if len(normal_danmaku) <= max_count:
+        final_normal = normal_danmaku
+    else:
+        # 计算时间窗口大小，确保弹幕均匀分布
+        window_size = (normal_danmaku[-1][0] - normal_danmaku[0][0]) / max_count
+
+        # 使用滑动窗口选择弹幕
+        final_normal: List[Tuple[float, str, str, str]] = []
+        current_window_start = normal_danmaku[0][0]
+        window_danmaku: List[Tuple[float, str, str, str]] = []
+
+        for i, item in enumerate(normal_danmaku):
+            ts = item[0]
+            if len(final_normal) + (len(normal_danmaku) - i) <= max_count:
+                if window_danmaku:
+                    mid_idx = len(window_danmaku) // 2
+                    final_normal.append(window_danmaku[mid_idx])
+                    window_danmaku = []
+                final_normal.extend(normal_danmaku[i:])
+                break
+
+            while ts > current_window_start + window_size:
+                if window_danmaku:
+                    mid_idx = len(window_danmaku) // 2
+                    final_normal.append(window_danmaku[mid_idx])
                 window_danmaku = []
-            # 剩下的弹幕全部加入
-            filtered_danmaku.extend(unique_danmaku[i:])
-            break
-        
-        # 如果当前弹幕时间超出了当前窗口
-        while timestamp > current_window_start + window_size:
-            # 从当前窗口中选择一条弹幕（如果有的话）
-            if window_danmaku:
-                # 选择窗口中间位置的弹幕
-                mid_idx = len(window_danmaku) // 2
-                filtered_danmaku.append(window_danmaku[mid_idx])
-            window_danmaku = []
-            current_window_start += window_size
-        
-        window_danmaku.append((timestamp, content))
-    
-    # 处理最后一个窗口的弹幕
-    if window_danmaku:
-        mid_idx = len(window_danmaku) // 2
-        filtered_danmaku.append(window_danmaku[mid_idx])
-    
-    return filtered_danmaku
+                current_window_start += window_size
+
+            window_danmaku.append(item)
+
+        if window_danmaku:
+            mid_idx = len(window_danmaku) // 2
+            final_normal.append(window_danmaku[mid_idx])
+
+    # 礼物弹幕保持原顺序加入
+    gifts = [d for d in unique_danmaku if d[3] == "gift"]
+    result = final_normal + gifts
+    result.sort(key=lambda x: x[0])
+
+    return [(ts, msg) for ts, msg, _, _ in result]
+
+
+def _parse_gift(elem: ET.Element, base_timestamp: float | None) -> tuple[float, str, str, str] | None:
+    """将礼物弹幕元素转换为时间戳和消息文本
+
+    返回 ``(time, message, original_content, 'gift')``，若 ``base_timestamp`` 未确定则返回 ``None``。
+    """
+    since_start = elem.get('since_start')
+    if since_start is not None:
+        time_stamp = float(since_start)
+    elif base_timestamp is not None:
+        abs_time = float(elem.get('timestamp', '0'))
+        time_stamp = abs_time - base_timestamp
+    else:
+        return None
+    uname = elem.get('username', '')
+    uid = elem.get('uid', '')
+    giftname = elem.get('giftname', '')
+    num = elem.get('num', '')
+    message = f"{uname}({uid}) 送出{giftname} x{num}"
+    original = f"{giftname} x{num}"
+    return time_stamp, message, original, "gift"
+
+
+def _flush_gifts(
+    pending_gifts: List[ET.Element],
+    base_timestamp: float,
+    danmaku_list: List[Tuple[float, str, str, str]],
+) -> None:
+    """将缓存的礼物弹幕转换为普通弹幕格式并加入列表"""
+    for g in pending_gifts:
+        parsed = _parse_gift(g, base_timestamp)
+        if parsed is not None:
+            danmaku_list.append(parsed)
+    pending_gifts.clear()
 
 def auto_send_danmaku(xml_path: str, video_cid: int, video_duration: int, bvid: str):
-    """自动发送XML文件中的弹幕"""
+    """根据XML文件内容自动发送弹幕
+
+    XML中 ``<d>`` 标签表示普通弹幕，``<s type="gift">`` 表示礼物弹幕。
+    礼物弹幕未来可能包含 ``since_start``，表示距离视频开始的时间；
+    若没有该字段，则通过 ``timestamp`` 与普通弹幕推算基准时间。
+    普通弹幕会封装为 ``[用户名]([用户id])：[内容]``，礼物弹幕会封装为
+    ``[用户名]([用户id]) 送出[礼物名称] x[礼物数量]``。
+    """
     
     start_time = time.time()  # 记录开始时间
     
     # 读取XML文件
     tree = ET.parse(xml_path)
     root = tree.getroot()
-    danmaku_list = []
-    
+    danmaku_list: List[Tuple[float, str, str, str]] = []
+    base_timestamp = None  # 视频开始的 Unix 时间戳
+    pending_gifts: List[ET.Element] = []
+
     # 收集所有弹幕
-    for d in root.findall('d'):
-        p_attrs = d.get('p').split(',')
-        time_stamp = float(p_attrs[0])
-        content = d.text
-        danmaku_list.append((time_stamp, content))
+    for elem in root:
+        if elem.tag == 'd':
+            # 普通弹幕
+            p_attr = elem.get('p')
+            rel_time = float(p_attr.split(',')[0]) if p_attr else 0.0
+            abs_time = float(elem.get('timestamp', '0'))
+
+            if base_timestamp is None:
+                base_timestamp = abs_time - rel_time
+                _flush_gifts(pending_gifts, base_timestamp, danmaku_list)
+
+            time_stamp = rel_time if p_attr else abs_time - base_timestamp
+
+            content = elem.text or ""
+            uname = elem.get('user', '')
+            uid = elem.get('uid', '')
+            message = f"{uname}({uid})：{content}"
+            danmaku_list.append((time_stamp, message, content, "d"))
+
+        elif elem.tag == 's' and elem.get('type') == 'gift':
+            parsed = _parse_gift(elem, base_timestamp)
+            if parsed is None:
+                pending_gifts.append(elem)
+            else:
+                danmaku_list.append(parsed)
+
+    # 若遍历结束后仍未确定基准时间，使用最早礼物弹幕时间作为基准
+    if pending_gifts:
+        if base_timestamp is None:
+            base_timestamp = float(pending_gifts[0].get('timestamp', '0'))
+        _flush_gifts(pending_gifts, base_timestamp, danmaku_list)
     
     # 过滤和均匀分布弹幕
     filtered_danmaku = filter_danmaku(
@@ -249,7 +328,10 @@ def auto_send_danmaku(xml_path: str, video_cid: int, video_duration: int, bvid: 
 
         # 并行发送当前批次的弹幕
         for j, (timestamp, content) in enumerate(batch_danmaku):
-            progress = min(int(timestamp * 1000) - 3000, video_duration * 1000)
+            progress = max(
+                min(int(timestamp * 1000) - 3000, video_duration * 1000),
+                0
+            )
             account_index = j % len(current_accounts)
             current_account = current_accounts[account_index]
             success, message, result = send_danmaku(


### PR DESCRIPTION
## Summary
- document gift `since_start` attribute
- parse `since_start` when present and fall back to timestamp
- refactor gift parsing into helpers
- keep original content for filtering; gifts bypass repeat/limit

## Testing
- `python3 -m py_compile src/api.py`
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684da8795d34832ca069a4e0d3cff265